### PR TITLE
Update plugin and support library

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,19 +2,19 @@ apply plugin: 'com.android.application'
 apply plugin: 'idea'
 
 android {
-    compileSdkVersion 21
-    buildToolsVersion "21.1.1"
+    compileSdkVersion 22
+    buildToolsVersion "22.0.1"
 
     defaultConfig {
         applicationId "io.vtm.mapapp"
         minSdkVersion 10
-        targetSdkVersion 21
+        targetSdkVersion 22
         versionCode 1
         versionName "1.0"
     }
     buildTypes {
         release {
-            runProguard false
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
@@ -27,7 +27,7 @@ idea {
 }
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:21.0.0'
+    compile 'com.android.support:appcompat-v7:22.1.1'
     compile 'org.oscim:vtm:0.6.0-SNAPSHOT'
     compile 'org.oscim:vtm-themes:0.6.0-SNAPSHOT'
     compile 'org.oscim:vtm-android:0.6.0-SNAPSHOT@aar'

--- a/app/src/main/java/io/vtm/mapapp/MapActivity.java
+++ b/app/src/main/java/io/vtm/mapapp/MapActivity.java
@@ -1,7 +1,7 @@
 package io.vtm.mapapp;
 
-import android.support.v7.app.ActionBarActivity;
 import android.os.Bundle;
+import android.support.v7.app.AppCompatActivity;
 import android.view.Menu;
 import android.view.MenuItem;
 
@@ -17,7 +17,7 @@ import org.oscim.tiling.TileSource;
 import org.oscim.tiling.source.oscimap4.OSciMap4TileSource;
 
 
-public class MapActivity extends ActionBarActivity {
+public class MapActivity extends AppCompatActivity {
 
     private MapView mMapView;
     private Map mMap;

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.13.2'
+        classpath 'com.android.tools.build:gradle:1.2.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.2.0'
+        classpath 'com.android.tools.build:gradle:1.2.2'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Nov 19 19:34:47 CET 2014
+#Wed Apr 29 09:11:30 AEST 2015
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.2.1-all.zip


### PR DESCRIPTION
Recent Android Studio versions complain about the Gradle plugin version and runProguard/minifyEnabled. After this is resolved, AS seems to forget about the repositories block of the root project and can't find the vtm jars in the maven repo. Updating to the latest plugin version fixes these issues.

Also changed MapActivity to extend from the new AppCompatActivity in support library 22.1.+, which deprecates ActionBarActivity.
